### PR TITLE
Turned the image import interface into an abstract class

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -64,7 +64,7 @@ int workers = 0;
 bool hasMoreFrames = true;
 
 // Processing module classes
-ImageImport importer("telemetry.csv", "", vector<int>());
+ImageImport * importer = NULL;
 TargetIdentifier identifier;
 
 void worker(Frame* f) {
@@ -78,7 +78,7 @@ void worker(Frame* f) {
 void read_images() {
     Frame* currentFrame;
     while (hasMoreFrames) {
-        Frame* f = importer.next_frame();
+        Frame* f = importer->next_frame();
         if (f) {
             in_buffer.push(f);
         }

--- a/modules/imgimport/include/imgimport.h
+++ b/modules/imgimport/include/imgimport.h
@@ -1,84 +1,48 @@
-/* 
-    This file is part of WARG's computer-vision
+/**
+ * @file imgimport.h
+ * @author WARG
+ *
+ * @section LICENSE
+ *
+ * Copyright (c) 2015-2016, Waterloo Aerial Robotics Group (WARG)
+ * All rights reserved.
+ *
+ * This software is licensed under a modified version of the BSD 3 clause license
+ * that should have been included with this software in a file called COPYING.txt
+ * Otherwise it is available at:
+ * https://raw.githubusercontent.com/UWARG/computer-vision/master/COPYING.txt
+ */
 
-    Copyright (c) 2015, Waterloo Aerial Robotics Group (WARG)
-    All rights reserved.
-
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-    1. Redistributions of source code must retain the above copyright
-       notice, this list of conditions and the following disclaimer.
-    2. Redistributions in binary form must reproduce the above copyright
-       notice, this list of conditions and the following disclaimer in the
-       documentation and/or other materials provided with the distribution.
-    3. Usage of this code MUST be explicitly referenced to WARG and this code 
-       cannot be used in any competition against WARG.
-    4. Neither the name of the WARG nor the names of its contributors may be used 
-       to endorse or promote products derived from this software without specific
-       prior written permission.
-
-    THIS SOFTWARE IS PROVIDED BY WARG ''AS IS'' AND ANY
-    EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-    DISCLAIMED. IN NO EVENT SHALL WARG BE LIABLE FOR ANY
-    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
-	
 #ifndef IMAGE_IMPORT_H_INCLUDED
 #define IMAGE_IMPORT_H_INCLUDED
 
 
 #include "frame.h"
-#include <opencv2/highgui/highgui.hpp>
 #include <string>
 #include <vector>
 
-/** 
+/**
  * @class ImageImport
  *
- * @brief Module for matching frames with telemetry information that 
- *        corresponds to them
- *
- * Reads Photographs and Video frames and creates a corresponding Frame object, adding 
- *  metadata information from a telemetry file
- * Handles image and video files as well as live video devices
- *
- * @section Notes   
- *
- * Ideally this should use both the timestamp in the image's
- * exif metadata and the time that the plane records sending
- * the signal to take a picture plus whatever delay that
- * exists between when the signal is sent to the camera and
- * when the camera takes the photograph.
+ * @brief Abstract class for importing frames and corresponding metadata
  *
  */
 
 class ImageImport {
-    public:
-        /**
-         * @brief Creates a ImageImport for the telemetry file at the given path
-         *
+public:
+    /**
+     * @brief
+     */
+    ImageImport();
 
-         *
-         * @param path Path of the telemetry file
-         * @param photoPath directory containing image and video files to import is required but does not need to contain photos
-         * @param videoDeviceNums indices of the video devices from which to read video frames
-         */
-        ImageImport(std::string telemetry_path, std::string filePath, std::vector<int> videoDeviceNums);
+    virtual ~ImageImport();
 
-        ~ImageImport();
-
-        /**
-         * @brief Retrieves the next frame to be analyzed
-         *
-         * @return Frame to be analyzed
-         */
-        Frame * next_frame();
+    /**
+     * @brief Retrieves the next frame to be analyzed
+     *
+     * @return Frame to be analyzed
+     */
+    virtual Frame * next_frame() = 0;
 };
 
 #endif // IMAGE_IMPORT_H_INCLUDED

--- a/modules/imgimport/src/imgimport.cpp
+++ b/modules/imgimport/src/imgimport.cpp
@@ -1,45 +1,17 @@
-/* 
-    This file is part of WARG's computer-vision
-
-    Copyright (c) 2015, Waterloo Aerial Robotics Group (WARG)
-    All rights reserved.
-
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-    1. Redistributions of source code must retain the above copyright
-       notice, this list of conditions and the following disclaimer.
-    2. Redistributions in binary form must reproduce the above copyright
-       notice, this list of conditions and the following disclaimer in the
-       documentation and/or other materials provided with the distribution.
-    3. Usage of this code MUST be explicitly referenced to WARG and this code
-       cannot be used in any competition against WARG.
-    4. Neither the name of the WARG nor the names of its contributors may be used
-       to endorse or promote products derived from this software without specific
-       prior written permission.
-
-    THIS SOFTWARE IS PROVIDED BY WARG ''AS IS'' AND ANY
-    EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-    DISCLAIMED. IN NO EVENT SHALL WARG BE LIABLE FOR ANY
-    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
+/*
+ * This file is part of WARG's computer-vision
+ *
+ * Copyright (c) 2015-2016, Waterloo Aerial Robotics Group (WARG)
+ * All rights reserved.
+ *
+ * This software is licensed under a modified version of the BSD 3 clause license
+ * that should have been included with this software in a file called COPYING.txt
+ * Otherwise it is available at:
+ * https://raw.githubusercontent.com/UWARG/computer-vision/master/COPYING.txt
+ */
 
 #include "imgimport.h"
-#include <vector>
 
-ImageImport::ImageImport(std::string telemetry_path, std::string filePath, std::vector<int> videoDeviceNums) {
+ImageImport::ImageImport() {
 
-}
-
-ImageImport::~ImageImport(){
-
-}
-
-Frame * ImageImport::next_frame(){
-    return NULL;
 }


### PR DESCRIPTION
Note that the constructor for ImageImport will need to have the telemetry log reader as a parameter once that is implemented.