### PR TITLE
re-added destructor for ImageImport class

### DIFF
--- a/modules/imgimport/src/imgimport.cpp
+++ b/modules/imgimport/src/imgimport.cpp
@@ -15,3 +15,7 @@
 ImageImport::ImageImport() {
 
 }
+
+ImageImport::~ImageImport() {
+
+}


### PR DESCRIPTION
Destructor implementation was inadvertently removed in previous modification of ImageImport, which causes a linker error if you try to implement and use a subclass of ImageImport.