### PR TITLE
Benchmarking and Contour comparison

### DIFF
--- a/modules/core/CMakeLists.txt
+++ b/modules/core/CMakeLists.txt
@@ -1,2 +1,2 @@
 include_directories(include)
-add_library(Core src/target.cpp src/pixel_target.cpp src/frame.cpp)
+add_library(Core src/target.cpp src/pixel_target.cpp src/frame.cpp src/benchmark.cpp)

--- a/modules/core/include/benchmark.h
+++ b/modules/core/include/benchmark.h
@@ -1,0 +1,28 @@
+/**
+ * @file benchmark.h
+ * @author WARG
+ *
+ * @section LICENSE
+ *
+ *  Copyright (c) 2015, Waterloo Aerial Robotics Group (WARG)
+ *  All rights reserved.
+ *
+ *  This software is licensed under a modified version of the BSD 3 clause license
+ *  that should have been included with this software in a file called COPYING.txt
+ *  Otherwise it is available at:
+ *  https://raw.githubusercontent.com/UWARG/computer-vision/master/COPYING.txt
+ */
+
+#ifndef BENCHMARK_H_INCLUDED
+#define BENCHMARK_H_INCLUDED
+
+#include <string>
+
+/**
+ *  @brief Does a benchmark of the given function and outputs the results to BOOST_TEST_MESSAGE
+ *  @param func Function to be run, should have minimal overhead (ideally setup beforehand and call with a lambda function)
+ *  @param iter Number of times the function will be run for profiling. The higher the better.
+ */
+void benchmark_function(std::string name, std::function<void ()> func, int iter = 100);
+
+#endif // BENCHMARK_H_INCLUDED

--- a/modules/core/src/benchmark.cpp
+++ b/modules/core/src/benchmark.cpp
@@ -1,0 +1,31 @@
+/**
+ * @file benchmark.cpp
+ * @author WARG
+ *
+ * @section LICENSE
+ *
+ *  Copyright (c) 2015, Waterloo Aerial Robotics Group (WARG)
+ *  All rights reserved.
+ *
+ *  This software is licensed under a modified version of the BSD 3 clause license
+ *  that should have been included with this software in a file called COPYING.txt
+ *  Otherwise it is available at:
+ *  https://raw.githubusercontent.com/UWARG/computer-vision/master/COPYING.txt
+ */
+
+#include <boost/test/unit_test.hpp>
+#include <string>
+#include <chrono>
+#include "benchmark.h"
+
+using namespace std;
+
+void benchmark_function(string name, std::function<void ()> func, int iter) {
+    auto start = chrono::steady_clock::now();
+    for(int i = 0; i < iter; i++) {
+        func();
+    }
+    auto end = chrono::steady_clock::now();
+    auto diff = end - start;
+    BOOST_TEST_MESSAGE("Benchmark of " << name << " took " << (chrono::duration <double, milli>(diff).count()/iter) << " ms per iteration");
+}

--- a/modules/targetid/CMakeLists.txt
+++ b/modules/targetid/CMakeLists.txt
@@ -1,6 +1,6 @@
 include_directories(include ../core/include)
 ADD_DEFINITIONS("-DBOOST_LOG_DYN_LINK")
-add_library(TargetIdentification src/target_identifier.cpp src/object_detector.cpp src/canny_contour_creator.cpp src/k_means_filter.cpp src/filter.cpp src/qr_identifier.cpp)
+add_library(TargetIdentification src/target_identifier.cpp src/object_detector.cpp src/canny_contour_creator.cpp src/k_means_filter.cpp src/filter.cpp src/qr_identifier.cpp src/contour_comparison.cpp)
 target_link_libraries(TargetIdentification ${OpenCV_LIBS} ${Boost_LIBRARIES} ${ZBAR_LIBRARIES} zbar Core)
 message("ZBAR: " + ${ZBAR_LIBRARIES})
 add_subdirectory("test")

--- a/modules/targetid/include/contour_comparison.h
+++ b/modules/targetid/include/contour_comparison.h
@@ -1,0 +1,36 @@
+/**
+ * @file contour_comparison.h
+ * @author WARG
+ *
+ * @section LICENSE
+ *
+ *  Copyright (c) 2015, Waterloo Aerial Robotics Group (WARG)
+ *  All rights reserved.
+ *
+ *  This software is licensed under a modified version of the BSD 3 clause license
+ *  that should have been included with this software in a file called COPYING.txt
+ *  Otherwise it is available at:
+ *  https://raw.githubusercontent.com/UWARG/computer-vision/master/COPYING.txt
+ */
+
+#ifndef CONTOUR_COMPARISON_H_INCLUDED
+#define CONTOUR_COMPARISION_H_INCLUDED
+
+#include <opencv2/imgproc.hpp>
+#include <vector>
+
+/**
+ *  @brief Compares two contours and returns their overlap
+ *
+ *  The return value uses the larger of the two contour sets as the base
+ *  This means that, for example, if the first set of contours encloses the second but is twice
+ *  as large, the resulting value will be 0.5, which is the same value as if the first was only
+ *  half the size as the second
+ *
+ *  @param contourA first contour to compare
+ *  @param contourB second contour to compare
+ *  @return Overlap between the two Contours, 1 being a complete match, 0 being a complete mismatch
+ */
+double compare_contours(std::vector<std::vector<cv::Point> > & contourA, std::vector<std::vector<cv::Point> > & contourB);
+
+#endif // CONTOUR_COMPARISON_H_INCLUDED

--- a/modules/targetid/src/contour_comparison.cpp
+++ b/modules/targetid/src/contour_comparison.cpp
@@ -1,0 +1,58 @@
+/**
+ * @file contour_comparison.cpp
+ * @author WARG
+ *
+ * @section LICENSE
+ *
+ *  Copyright (c) 2015, Waterloo Aerial Robotics Group (WARG)
+ *  All rights reserved.
+ *
+ *  This software is licensed under a modified version of the BSD 3 clause license
+ *  that should have been included with this software in a file called COPYING.txt
+ *  Otherwise it is available at:
+ *  https://raw.githubusercontent.com/UWARG/computer-vision/master/COPYING.txt
+ */
+
+#include <opencv2/imgproc.hpp>
+#include <boost/log/trivial.hpp>
+#include <boost/test/unit_test.hpp>
+#include <vector>
+#include "contour_comparison.h"
+
+using namespace cv;
+using namespace std;
+
+double compare_contours(vector<vector<Point> > & contourA, vector<vector<Point> > & contourB) {
+    BOOST_LOG_TRIVIAL(trace) << "Comparing contours";
+    if (contourA.size() == 0 || contourB.size() == 0) return 0;
+    Rect boundsA;
+    Rect boundsB;
+    for(int i = 0; i < contourA.size(); i++) boundsA |= boundingRect(contourA[i]);
+    for(int i = 0; i < contourB.size(); i++) boundsB |= boundingRect(contourB[i]);
+    Size largest = Size(boundsA.x + boundsA.width > boundsB.x + boundsB.width
+                        ? boundsA.x + boundsA.width : boundsB.x + boundsB.width,
+                        boundsA.y + boundsA.height > boundsB.y + boundsB.height
+                        ? boundsA.y + boundsA.height : boundsB.y + boundsB.height);
+    Mat imgA = Mat::zeros(largest, CV_8U);
+    Mat imgB = Mat::zeros(largest, CV_8U);
+    BOOST_LOG_TRIVIAL(trace) << "Drawing contours";
+    vector<vector<Point> >hullA(contourA.size()), hullB(contourB.size());
+
+    for(int i = 0; i < hullA.size(); i++) {
+        convexHull( Mat(contourA[i]), hullA[i], false );
+        drawContours(imgA, hullA, i, Scalar(255,255,255), FILLED);
+    }
+    for(int i = 0; i < hullB.size(); i++) {
+        convexHull( Mat(contourB[i]), hullB[i], false );
+        drawContours(imgB, hullB, i, Scalar(255,255,255), FILLED);
+    }
+    BOOST_LOG_TRIVIAL(trace) << "Comparing images";
+    Mat diff = imgA & imgB;
+    int countA = countNonZero(imgA);
+    int countB = countNonZero(imgB);
+    double countDiff = countNonZero(diff);
+    double base = countA > countB ? countA : countB;
+    BOOST_LOG_TRIVIAL(info) << "Size(contourA) = " << countA << ", Size(contourB) = " << countB << " Size(difference) = " << countDiff;
+    BOOST_LOG_TRIVIAL(info) << "Result: " << (countDiff/base);
+    return countDiff/base;
+}

--- a/modules/targetid/test/test.cpp
+++ b/modules/targetid/test/test.cpp
@@ -41,6 +41,8 @@
 #include "canny_contour_creator.h"
 #include "k_means_filter.h"
 #include "frame.h"
+#include "benchmark.h"
+#include "contour_comparison.h"
 
 using namespace cv;
 using namespace std;
@@ -63,7 +65,7 @@ ostream & operator<<(ostream & out, vector<vector<Point_<int> > > & contour) {
 }
 
 BOOST_AUTO_TEST_CASE(KMeansAndCanny) {
-    vector<Point> * expected = new vector<Point>({Point(1445, 480), Point(1458, 405), Point(1535, 423), Point(1518, 496)});
+    vector<vector<Point> > * expected = new vector<vector<Point> >({vector<Point>({Point(1445, 480), Point(1458, 405), Point(1535, 423), Point(1518, 496), Point(1445, 480)})});
     if (boost::unit_test::framework::master_test_suite().argc < 2) {
         BOOST_ERROR("Invalid number of arguments");
     }
@@ -73,10 +75,10 @@ BOOST_AUTO_TEST_CASE(KMeansAndCanny) {
     CannyContourCreator ccreator;
     Mat * filtered = filter.filter(f.get_img());
     vector<vector<Point> > * results = ccreator.get_contours(*filtered);
-    BOOST_CHECK(true); // TODO: This test should be done by converting contours to binary mats and comparing overlap
-    stringstream resultstr, expectedstr;
-    resultstr << *results;
-    expectedstr << *expected;
-    BOOST_TEST_MESSAGE("RESULT: " << resultstr.str());
-    BOOST_TEST_MESSAGE("EXPECTED: " << expectedstr.str());
+
+    double diff = compare_contours(*results, *expected);
+    BOOST_CHECK(diff > 0.01); // ensures that at least something is detected
+    BOOST_TEST_MESSAGE("RESULT: " << diff);
+
+    benchmark_function("k_means", [&]() { filter.filter(f.get_img()); }, 10);
 }


### PR DESCRIPTION
Added benchmarking functions and contour comparison for properly checking accuracy of object detection algs.

Contour comparison determines overlap by converting the contours into binary mats using the filled convex hull of each contour, ANDing the binary mats and comparing the amount of non-zero pixels in the resulting mat to that of the larger of the two originals.