### PR TITLE
Video import

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -49,6 +49,7 @@
 #include "pictureimport.h"
 #include "metadata_input.h"
 #include "target.h"
+#include "video_import.h"
 
 using namespace std;
 using namespace boost;
@@ -104,6 +105,7 @@ void read_images() {
             Frame* f = importer->next_frame();
             if (f) {
                 in_buffer.push(f);
+                BOOST_LOG_TRIVIAL(trace) << "Adding frame to buffer";
             }
             else {
                 hasMoreFrames = false;
@@ -194,7 +196,8 @@ int handle_args(int argc, char** argv) {
             ("addr,a", po::value<string>(), "Address to connect to to recieve telemetry log")
             ("port,p", po::value<string>(), "Port to connect to to recieve telemetry log")
             ("output,o", po::value<string>(), "Directory to store output files; default is current directory")
-            ("intermediate", "When this is enabled, program will output intermediary frames that contain objects of interest");
+            ("intermediate", "When this is enabled, program will output intermediary frames that contain objects of interest")
+            ("videofile,f", po::value<string>(), "Path to video file to read frames from");
 
         po::variables_map vm;
         po::store(po::parse_command_line(argc, argv, description), vm);
@@ -204,8 +207,7 @@ int handle_args(int argc, char** argv) {
             cout << description << endl;
             return 1;
         }
-
-        int devices = vm.count("video") + vm.count("decklink") + vm.count("images");
+        int devices = vm.count("video") + vm.count("decklink") + vm.count("images") + vm.count("videofile");
         if (devices > 1) {
             cout << "Invalid options: You can only specify one image source at a time" << endl;
             return 1;
@@ -233,6 +235,11 @@ int handle_args(int argc, char** argv) {
         if (vm.count("images")) {
             string path = vm["images"].as<string>();
             importer = new PictureImport(path, logReader);
+        }
+
+        if (vm.count("videofile")) {
+            string path = vm["videofile"].as<string>();
+            importer = new VideoImport(path, logReader);
         }
 
         if (vm.count("output")) {

--- a/modules/imgimport/CMakeLists.txt
+++ b/modules/imgimport/CMakeLists.txt
@@ -7,7 +7,7 @@ if (DeckLinkSDK_FOUND)
     set(DeckLinkFiles ${DeckLinkSDK_LIBS} ${DeckLinkSDK_SRC_FILE} src/DeckLinkCapture.cpp src/DeckLinkOpenCv.cpp src/DeckLinkInputCallback.cpp)
 endif (DeckLinkSDK_FOUND)
 
-add_library(ImageImport src/imgimport.cpp src/decklink_import.cpp src/pictureimport.cpp src/metadata_input.cpp ${DeckLinkFiles})
+add_library(ImageImport src/imgimport.cpp src/decklink_import.cpp src/pictureimport.cpp src/metadata_input.cpp src/video_import.cpp ${DeckLinkFiles})
 target_link_libraries(ImageImport ${Boost_LIBRARIES} Core)
 
 add_subdirectory("test")

--- a/modules/imgimport/include/video_import.h
+++ b/modules/imgimport/include/video_import.h
@@ -1,0 +1,46 @@
+/**
+ * @file video_import.h
+ * @author WARG
+ *
+ * @section LICENSE
+ *
+ * Copyright (c) 2015-2016, Waterloo Aerial Robotics Group (WARG)
+ * All rights reserved.
+ *
+ * This software is licensed under a modified version of the BSD 3 clause license
+ * that should have been included with this software in a file called COPYING.txt
+ * Otherwise it is available at:
+ * https://raw.githubusercontent.com/UWARG/computer-vision/master/COPYING.txt
+ */
+
+#ifndef VIDEO_IMPORT_H_INCLUDED
+#define VIDEO_IMPORT_H_INCLUDED
+
+#include "imgimport.h"
+#include "metadata_input.h"
+#include "frame.h"
+#include <opencv2/highgui/highgui.hpp>
+
+/**
+ * @class VideoImport
+ *
+ * Class for reading MP4 video files
+ */
+class VideoImport : public ImageImport {
+public:
+    /**
+     *  @param videoFile video file to be read
+     *  @param reader log reader containing telemetry data for the video
+     */
+    VideoImport(std::string videoFile, MetadataInput * reader);
+
+    virtual Frame * next_frame();
+
+private:
+    cv::VideoCapture capture;
+    double totalFrames;
+    std::string fileName;
+    double videoStartTime;
+};
+
+#endif // VIDEO_IMPORT_H_INCLUDED

--- a/modules/imgimport/include/video_import.h
+++ b/modules/imgimport/include/video_import.h
@@ -40,7 +40,7 @@ private:
     cv::VideoCapture capture;
     double totalFrames;
     std::string fileName;
-    double videoStartTime;
+    std::time_t videoStartTime;
 };
 
 #endif // VIDEO_IMPORT_H_INCLUDED

--- a/modules/imgimport/src/video_import.cpp
+++ b/modules/imgimport/src/video_import.cpp
@@ -1,0 +1,62 @@
+/**
+ * @file video_import.cpp
+ * @author WARG
+ *
+ * @section LICENSE
+ *
+ * Copyright (c) 2015-2016, Waterloo Aerial Robotics Group (WARG)
+ * All rights reserved.
+ *
+ * This software is licensed under a modified version of the BSD 3 clause license
+ * that should have been included with this software in a file called COPYING.txt
+ * Otherwise it is available at:
+ * https://raw.githubusercontent.com/UWARG/computer-vision/master/COPYING.txt
+ */
+
+#include "video_import.h"
+#include <boost/log/trivial.hpp>
+#include <boost/date_time/posix_time/posix_time.hpp>
+
+using namespace cv;
+using namespace std;
+using namespace boost;
+
+VideoImport::VideoImport(string videoFile, MetadataInput * reader) : ImageImport(reader) {
+    capture.open(videoFile);
+    if (!capture.isOpened()) {
+        BOOST_LOG_TRIVIAL(error) << "Cannot open video file " << videoFile;
+        throw std::exception();
+    }
+    capture.set(CAP_PROP_CONVERT_RGB, true);
+    totalFrames = capture.get(CAP_PROP_FRAME_COUNT);
+    fileName = videoFile.find_last_of('/') == string::npos ? videoFile : videoFile.substr(videoFile.find_last_of('/'));
+    // TODO: Read video modified time from filesystem
+}
+
+Frame * VideoImport::next_frame() {
+    Mat * frame = new Mat();
+    bool success = capture.read(*frame);
+
+    if (!success) {
+        BOOST_LOG_TRIVIAL(info) << "No more video frames, stopping.";
+        return NULL;
+    }
+
+    double pos = capture.get(CAP_PROP_POS_MSEC);
+    double frameTime = videoStartTime + pos;
+
+    // TODO: Use video modified time and video position to find frame time
+
+    const posix_time::ptime now = posix_time::microsec_clock::local_time();
+
+    const posix_time::time_duration td = now.time_of_day();
+
+    const long hours        = td.hours();
+    const long minutes      = td.minutes();
+    const long seconds      = td.seconds();
+    const long milliseconds = td.total_milliseconds() -
+                              ((hours * 3600 + minutes * 60 + seconds) * 1000);
+    double time = hours * 10000 + minutes * 100 + seconds + ((double)milliseconds)/1000;
+
+    return new Frame(frame, fileName + boost::lexical_cast<string>(time) + ".jpg", reader->get_metadata(time));
+}

--- a/modules/imgimport/src/video_import.cpp
+++ b/modules/imgimport/src/video_import.cpp
@@ -16,10 +16,13 @@
 #include "video_import.h"
 #include <boost/log/trivial.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>
+#include <boost/filesystem.hpp>
+#include <ctime>
 
 using namespace cv;
 using namespace std;
 using namespace boost;
+using namespace boost::filesystem;
 
 VideoImport::VideoImport(string videoFile, MetadataInput * reader) : ImageImport(reader) {
     capture.open(videoFile);
@@ -30,7 +33,7 @@ VideoImport::VideoImport(string videoFile, MetadataInput * reader) : ImageImport
     capture.set(CAP_PROP_CONVERT_RGB, true);
     totalFrames = capture.get(CAP_PROP_FRAME_COUNT);
     fileName = videoFile.find_last_of('/') == string::npos ? videoFile : videoFile.substr(videoFile.find_last_of('/'));
-    // TODO: Read video modified time from filesystem
+    videoStartTime = last_write_time(fileName);
 }
 
 Frame * VideoImport::next_frame() {
@@ -43,20 +46,10 @@ Frame * VideoImport::next_frame() {
     }
 
     double pos = capture.get(CAP_PROP_POS_MSEC);
-    double frameTime = videoStartTime + pos;
+    time_t frameTime = videoStartTime + pos / 1000;
+    tm * utcTime = gmtime(&frameTime);
 
-    // TODO: Use video modified time and video position to find frame time
-
-    const posix_time::ptime now = posix_time::microsec_clock::local_time();
-
-    const posix_time::time_duration td = now.time_of_day();
-
-    const long hours        = td.hours();
-    const long minutes      = td.minutes();
-    const long seconds      = td.seconds();
-    const long milliseconds = td.total_milliseconds() -
-                              ((hours * 3600 + minutes * 60 + seconds) * 1000);
-    double time = hours * 10000 + minutes * 100 + seconds + ((double)milliseconds)/1000;
+    double time = utcTime->tm_hour * 10000 + utcTime->tm_min * 100 + utcTime->tm_sec + ((int)floor(pos) % 1000)/1000;
 
     return new Frame(frame, fileName + boost::lexical_cast<string>(time) + ".jpg", reader->get_metadata(time));
 }

--- a/modules/imgimport/test/test.cpp
+++ b/modules/imgimport/test/test.cpp
@@ -1,9 +1,9 @@
-/* 
+/*
     This file is part of WARG's computer-vision
 
     Copyright (c) 2015, Waterloo Aerial Robotics Group (WARG)
     All rights reserved.
- 
+
     Redistribution and use in source and binary forms, with or without
     modification, are permitted provided that the following conditions are met:
     1. Redistributions of source code must retain the above copyright
@@ -51,8 +51,8 @@ BOOST_AUTO_TEST_CASE(DecklinkVideoSource){
     DecklinkImport * v = new DecklinkImport(NULL);
     cv::Mat img;
     v->grabFrame(&img);
-    
-    BOOST_CHECK(img.rows > 0);   
+
+    BOOST_CHECK(img.rows > 0);
     delete v;
-   
+
 }


### PR DESCRIPTION
Currently uses video file modification time and seek position to get frame time.
The video start time is probably stored in the metadata of the gopro video, but it doesn't sound like there is a standard way this is done, so we will have to look at how the gopro specifically stores the timestamp, and add that functionality later, using modification time as a backup.
