### PR TITLE
DeckLinkImport fix

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -226,7 +226,7 @@ int handle_args(int argc, char** argv) {
 
 #ifdef HAS_DECKLINK
         if (vm.count("decklink")) {
-            importer = new DecklinkImport(logReader);
+            importer = new DeckLinkImport(logReader);
         }
 #endif // HAS_DECKLINK
 

--- a/modules/imgimport/include/decklink_import.h
+++ b/modules/imgimport/include/decklink_import.h
@@ -40,9 +40,9 @@
 #include "imgimport.h"
 
 /**
- * @class DecklinkImport
+ * @class DeckLinkImport
  *
- * @brief Module for extracting frames from Decklink Video cards.
+ * @brief Module for extracting frames from DeckLink Video cards.
  *
  * Reads Video frames and processes them into a OpenCV friendly format. 
  * The results are later used in the ImageImport class. 
@@ -56,14 +56,14 @@
  *
  */
 
-class DecklinkImport : public ImageImport {
+class DeckLinkImport : public ImageImport {
     public:
         /**
-         * Creates a DecklinkImport object
+         * Creates a DeckLinkImport object
          */
-        DecklinkImport(MetadataInput * reader);
+        DeckLinkImport(MetadataInput * reader);
 
-        virtual ~DecklinkImport();
+        virtual ~DeckLinkImport();
 
         /**
          * Begins capture. Creates a video stream which a frame may be grabbed from.
@@ -95,7 +95,7 @@ class DecklinkImport : public ImageImport {
         virtual Frame* next_frame();
     private:
         /**
-         * Function called when the DecklinkImport object is initialized. The module looks for
+         * Function called when the DeckLinkImport object is initialized. The module looks for
          * the decklink drivers, decklink device and prepares the hardware for capture.
          *
          * @return Status depicting whether or not the initialization process was successful.

--- a/modules/imgimport/src/decklink_import.cpp
+++ b/modules/imgimport/src/decklink_import.cpp
@@ -38,7 +38,7 @@
 #include <boost/foreach.hpp>
 #include <boost/format.hpp>
 
-//If not using Decklink, omit the rest of the code. Note, if more cameras are added into this suite, this will need to change.
+//If not using DeckLink, omit the rest of the code. Note, if more cameras are added into this suite, this will need to change.
 #ifdef HAS_DECKLINK
 
 #include <DeckLinkAPI.h>
@@ -61,18 +61,18 @@ IDeckLink* deckLink;
 
 Frame* img;
 
-DecklinkImport::DecklinkImport(MetadataInput * reader) : ImageImport(reader){
+DeckLinkImport::DeckLinkImport(MetadataInput * reader) : ImageImport(reader){
     initVideoSource();
     startCapture();
     img = (Frame*) malloc(sizeof(Frame));
 }
 
-DecklinkImport::~DecklinkImport(){
+DeckLinkImport::~DeckLinkImport(){
     stopCapture();
     free(img);
 }
 
-int DecklinkImport::initVideoSource()
+int DeckLinkImport::initVideoSource()
 {
     ComPtr<IDeckLinkIterator> deckLinkIterator = CreateDeckLinkIteratorInstance();
     if (! deckLinkIterator) {
@@ -111,7 +111,7 @@ int DeckLinkImport::startCapture(){
     return 0;
 }
 
-int DecklinkImport::stopCapture(){
+int DeckLinkImport::stopCapture(){
     BOOST_FOREACH(DeckLinkCapture& capture, captures)
     {
         capture.stop();
@@ -119,7 +119,7 @@ int DecklinkImport::stopCapture(){
     return 0;
 }
 
-int DecklinkImport::grabFrame(cv::Mat* frame){
+int DeckLinkImport::grabFrame(cv::Mat* frame){
     BOOST_FOREACH(DeckLinkCapture& capture, captures)
     {
         capture.grab();
@@ -130,7 +130,7 @@ int DecklinkImport::grabFrame(cv::Mat* frame){
     return 0;
 }
 
-Frame* DecklinkImport::next_frame(){
+Frame* DeckLinkImport::next_frame(){
     cv::Mat oFrame;
     grabFrame(&oFrame);
     //Insert string id and metadata once a ID generator has been coded and the metadata generator has been coded.

--- a/modules/imgimport/src/decklink_import.cpp
+++ b/modules/imgimport/src/decklink_import.cpp
@@ -53,6 +53,7 @@
 #include "decklink_import.h"
 
 using namespace boost;
+using std::string;
 
 namespace logging = boost::log;
 

--- a/modules/imgimport/test/test.cpp
+++ b/modules/imgimport/test/test.cpp
@@ -48,11 +48,11 @@ BOOST_AUTO_TEST_CASE(DecklinkVideoSource){
         BOOST_ERROR("Invalid number of arguments");
     }
 
-    DecklinkImport * v = new DecklinkImport(NULL);
+    DeckLinkImport * v = new DeckLinkImport(NULL);
     cv::Mat img;
     v->grabFrame(&img);
-    
-    BOOST_CHECK(img.rows > 0);   
+
+    BOOST_CHECK(img.rows > 0);
     delete v;
    
 }


### PR DESCRIPTION
Fixed inconsistent case (Decklink vs DeckLink) causing build failures when DeckLink support is built.
Fixed references to string without a namespace in decklink_import.cpp