### PR TITLE
Decklink libdl build regression fix

### DIFF
--- a/modules/imgimport/CMakeLists.txt
+++ b/modules/imgimport/CMakeLists.txt
@@ -8,7 +8,7 @@ if (DeckLinkSDK_FOUND)
 endif (DeckLinkSDK_FOUND)
 
 add_library(ImageImport src/imgimport.cpp src/decklink_import.cpp src/pictureimport.cpp src/metadata_input.cpp ${DeckLinkFiles})
-target_link_libraries(ImageImport ${Boost_LIBRARIES} Core)
+target_link_libraries(ImageImport ${Boost_LIBRARIES} Core dl)
 
 add_subdirectory("test")
 


### PR DESCRIPTION
A system update caused a linking error when linking the decklink library.
```
/usr/bin/ld: modules/imgimport/libImageImport.a(DeckLinkAPIDispatch.cpp.o): undefined reference to symbol 'dlsym@@GLIBC_2.2.5'
/lib/x86_64-linux-gnu/libdl.so.2: error adding symbols: DSO missing from command line
```
Linking libdl into ImageImport fixes the issue