### PR TITLE
Video Import

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -54,6 +54,7 @@
 #include "metadata_reader.h"
 #include "target.h"
 #include "camera.h"
+#include "video_import.h"
 
 using namespace std;
 using namespace boost;
@@ -384,7 +385,8 @@ int handle_args(int argc, char** argv) {
             ("addr,a", po::value<string>(), "Address to connect to to recieve telemetry log")
             ("port,p", po::value<string>(), "Port to connect to to recieve telemetry log")
             ("output,o", po::value<string>(), "Directory to store output files; default is current directory")
-            ("intermediate", "When this is enabled, program will output intermediary frames that contain objects of interest");
+            ("intermediate", "When this is enabled, program will output intermediary frames that contain objects of interest")
+            ("videofile,f", po::value<string>(), "Path to video file to read frames from");
 
         po::variables_map vm;
         po::store(po::parse_command_line(argc, argv, description), vm);
@@ -422,6 +424,13 @@ int handle_args(int argc, char** argv) {
             importer.add_source(new PictureImport(path, logReader, goProFisheye), 0);
             newState.hasImageSource = true;
             cout << "Adding picture source..." << endl;
+        }
+
+        if (vm.count("videofile")) {
+            string path = vm["videofile"].as<string>();
+            importer.add_source(new VideoImport(path, logReader, goProRect), 100);
+            newState.hasImageSource = true;
+            cout << "Adding video source..." << endl;
         }
 
         if (vm.count("output")) {

--- a/main.cpp
+++ b/main.cpp
@@ -308,6 +308,14 @@ vector<Command> commands = {
             newState.hasImageSource = true;
         }
     }),
+    Command("frames.source.videofile.add", "", {"path", "delay", "frameSkipMs"}, [=](State &newState, vector<string> args) {
+        if (logReader->num_sources() == 0) {
+            BOOST_LOG_TRIVIAL(error) << "Cannot add image source until a metadata source has been specified";
+        } else {
+            importer.add_source(new VideoImport(args[0], logReader, goProFisheye, stol(args[2])), stol(args[1]));
+            newState.hasImageSource = true;
+        }
+    }),
 #ifdef HAS_DECKLINK
     Command("frames.source.decklink.add", "", {"delay"}, [=](State &newState, vector<string> args) {
         if (logReader->num_sources() == 0) {
@@ -321,6 +329,10 @@ vector<Command> commands = {
     Command("frames.source.remove", "Removes the source at the given index", {"index"}, [=](State &newState, vector<string> args) {
         importer.remove_source(stoi(args[0]));
         newState.hasImageSource = importer.num_sources() > 0;
+    }),
+    Command("frames.source.list", "Lists frame sources", {}, [=](State &newState, vector<string> args) {
+        cout << importer.source_descriptions() << endl;
+
     }),
     Command("frames.source.update_delay", "Updates the delay for the source at the given index", {"index", "delay"}, [=](State &newState, vector<string> args) {
         importer.update_delay(stoi(args[0]), stol(args[1]));
@@ -428,7 +440,7 @@ int handle_args(int argc, char** argv) {
 
         if (vm.count("videofile")) {
             string path = vm["videofile"].as<string>();
-            importer.add_source(new VideoImport(path, logReader, goProRect), 100);
+            importer.add_source(new VideoImport(path, logReader, goProRect, 0), 100);
             newState.hasImageSource = true;
             cout << "Adding video source..." << endl;
         }

--- a/modules/imgimport/CMakeLists.txt
+++ b/modules/imgimport/CMakeLists.txt
@@ -7,7 +7,7 @@ if (DeckLinkSDK_FOUND)
     set(DeckLinkFiles ${DeckLinkSDK_LIBS} ${DeckLinkSDK_SRC_FILE} src/DeckLinkCapture.cpp src/DeckLinkOpenCv.cpp src/DeckLinkInputCallback.cpp)
 endif (DeckLinkSDK_FOUND)
 
-add_library(ImageImport src/imgimport.cpp src/decklink_import.cpp src/pictureimport.cpp src/metadata_input.cpp src/metadata_reader.cpp src/importer.cpp ${DeckLinkFiles})
+add_library(ImageImport src/imgimport.cpp src/decklink_import.cpp src/pictureimport.cpp src/metadata_input.cpp src/metadata_reader.cpp src/importer.cpp src/video_import.cpp ${DeckLinkFiles})
 target_link_libraries(ImageImport ${Boost_LIBRARIES} Core dl)
 
 add_subdirectory("test")

--- a/modules/imgimport/include/decklink_import.h
+++ b/modules/imgimport/include/decklink_import.h
@@ -93,6 +93,11 @@ class DeckLinkImport : public ImageImport {
          * @return A frame from the video for further usage in further computations and analysis.
          */
         virtual Frame* next_frame();
+
+        /**
+         * @brief String representation of the Importer
+         */
+        virtual std::string to_string();
     private:
         /**
          * Function called when the DeckLinkImport object is initialized. The module looks for

--- a/modules/imgimport/include/imgimport.h
+++ b/modules/imgimport/include/imgimport.h
@@ -44,6 +44,11 @@ public:
      */
     virtual Frame * next_frame() = 0;
 
+    /**
+     * @brief String representation of the Importer
+     */
+    virtual std::string to_string() = 0;
+
 protected:
     MetadataInput * reader;
     Camera &camera;

--- a/modules/imgimport/include/importer.h
+++ b/modules/imgimport/include/importer.h
@@ -88,6 +88,11 @@ public:
      * @returns current buffer size
      */
     int get_buffer_size();
+
+    /**
+     * @brief Returns string containing human readable descriptions of the current input sources
+     */
+    std::string source_descriptions();
 private:
     boost::asio::io_service ioService;
     std::vector<Source *> sources;

--- a/modules/imgimport/include/pictureimport.h
+++ b/modules/imgimport/include/pictureimport.h
@@ -46,6 +46,11 @@ public:
      * @return Frame to be analyzed
      */
     Frame* next_frame();
+
+    /**
+     * @brief String representation of the Importer
+     */
+    virtual std::string to_string();
 private:
     std::string filePath;
     DIR* dr;

--- a/modules/imgimport/include/video_import.h
+++ b/modules/imgimport/include/video_import.h
@@ -1,0 +1,47 @@
+/**
+ * @file video_import.h
+ * @author WARG
+ *
+ * @section LICENSE
+ *
+ * Copyright (c) 2015-2016, Waterloo Aerial Robotics Group (WARG)
+ * All rights reserved.
+ *
+ * This software is licensed under a modified version of the BSD 3 clause license
+ * that should have been included with this software in a file called COPYING.txt
+ * Otherwise it is available at:
+ * https://raw.githubusercontent.com/UWARG/computer-vision/master/COPYING.txt
+ */
+
+#ifndef VIDEO_IMPORT_H_INCLUDED
+#define VIDEO_IMPORT_H_INCLUDED
+
+#include "imgimport.h"
+#include "metadata_input.h"
+#include "frame.h"
+#include "camera.h"
+#include <opencv2/highgui/highgui.hpp>
+
+/**
+ * @class VideoImport
+ *
+ * Class for reading MP4 video files
+ */
+class VideoImport : public ImageImport {
+public:
+    /**
+     *  @param videoFile video file to be read
+     *  @param reader log reader containing telemetry data for the video
+     */
+    VideoImport(std::string videoFile, MetadataInput * reader, Camera &camera);
+
+    virtual Frame * next_frame();
+
+private:
+    cv::VideoCapture capture;
+    double totalFrames;
+    std::string fileName;
+    double videoStartTime;
+};
+
+#endif // VIDEO_IMPORT_H_INCLUDED

--- a/modules/imgimport/include/video_import.h
+++ b/modules/imgimport/include/video_import.h
@@ -41,7 +41,7 @@ private:
     cv::VideoCapture capture;
     double totalFrames;
     std::string fileName;
-    double videoStartTime;
+    std::time_t videoStartTime;
 };
 
 #endif // VIDEO_IMPORT_H_INCLUDED

--- a/modules/imgimport/include/video_import.h
+++ b/modules/imgimport/include/video_import.h
@@ -33,15 +33,20 @@ public:
      *  @param videoFile video file to be read
      *  @param reader log reader containing telemetry data for the video
      */
-    VideoImport(std::string videoFile, MetadataInput * reader, Camera &camera);
+    VideoImport(std::string videoFile, MetadataInput * reader, Camera &camera, long frameSkipMs);
 
     virtual Frame * next_frame();
 
+    /**
+     * @brief String representation of the Importer
+     */
+    virtual std::string to_string();
 private:
     cv::VideoCapture capture;
     double totalFrames;
     std::string fileName;
     std::time_t videoStartTime;
+    long frameSkipMs;
 };
 
 #endif // VIDEO_IMPORT_H_INCLUDED

--- a/modules/imgimport/src/decklink_import.cpp
+++ b/modules/imgimport/src/decklink_import.cpp
@@ -154,4 +154,8 @@ Frame* DeckLinkImport::next_frame(){
     Frame* img = new Frame(&oFrame, boost::lexical_cast<string>(time) + ".jpg", m);
     return img;
 }
+
+std::string DeckLinkImport::to_string() {
+    return "DecklinkImport";
+}
 #endif

--- a/modules/imgimport/src/importer.cpp
+++ b/modules/imgimport/src/importer.cpp
@@ -70,6 +70,11 @@ public:
     void set_delay(long msdelay) {
         this->msdelay = msdelay;
     }
+
+    friend ostream &operator<<(ostream &output, const Source &S) {
+        output << "Importer : " << S.importer->to_string() << " delay : " << S.msdelay << " running: " << S.running;
+        return output;
+    }
 private:
     ImageImport *importer;
     priority_queue<Frame*> &cache;
@@ -126,4 +131,12 @@ void Importer::set_buffer_size(int bufferSize) {
 
 int Importer::get_buffer_size() {
     return this->bufferSize;
+}
+
+std::string Importer::source_descriptions() {
+    stringstream ss;
+    for (int i = 0; i < sources.size(); i++) {
+        ss << i << ": " << *(sources[i]) << std::endl;
+    }
+    return ss.str();
 }

--- a/modules/imgimport/src/pictureimport.cpp
+++ b/modules/imgimport/src/pictureimport.cpp
@@ -64,3 +64,7 @@ Frame * PictureImport::next_frame(){
     }
     return new Frame(img, id, m, camera);
 }
+
+std::string PictureImport::to_string() {
+    return "PictureImport";
+}

--- a/modules/imgimport/src/video_import.cpp
+++ b/modules/imgimport/src/video_import.cpp
@@ -1,0 +1,62 @@
+/**
+ * @file video_import.cpp
+ * @author WARG
+ *
+ * @section LICENSE
+ *
+ * Copyright (c) 2015-2016, Waterloo Aerial Robotics Group (WARG)
+ * All rights reserved.
+ *
+ * This software is licensed under a modified version of the BSD 3 clause license
+ * that should have been included with this software in a file called COPYING.txt
+ * Otherwise it is available at:
+ * https://raw.githubusercontent.com/UWARG/computer-vision/master/COPYING.txt
+ */
+
+#include "video_import.h"
+#include <boost/log/trivial.hpp>
+#include <boost/date_time/posix_time/posix_time.hpp>
+
+using namespace cv;
+using namespace std;
+using namespace boost;
+
+VideoImport::VideoImport(string videoFile, MetadataInput * reader, Camera &camera) : ImageImport(reader, camera) {
+    capture.open(videoFile);
+    if (!capture.isOpened()) {
+        BOOST_LOG_TRIVIAL(error) << "Cannot open video file " << videoFile;
+        throw std::exception();
+    }
+    capture.set(CAP_PROP_CONVERT_RGB, true);
+    totalFrames = capture.get(CAP_PROP_FRAME_COUNT);
+    fileName = videoFile.find_last_of('/') == string::npos ? videoFile : videoFile.substr(videoFile.find_last_of('/'));
+    // TODO: Read video modified time from filesystem
+}
+
+Frame * VideoImport::next_frame() {
+    Mat * frame = new Mat();
+    bool success = capture.read(*frame);
+
+    if (!success) {
+        BOOST_LOG_TRIVIAL(info) << "No more video frames, stopping.";
+        return NULL;
+    }
+
+    double pos = capture.get(CAP_PROP_POS_MSEC);
+    double frameTime = videoStartTime + pos;
+
+    // TODO: Use video modified time and video position to find frame time
+
+    const posix_time::ptime now = posix_time::microsec_clock::local_time();
+
+    const posix_time::time_duration td = now.time_of_day();
+
+    const long hours        = td.hours();
+    const long minutes      = td.minutes();
+    const long seconds      = td.seconds();
+    const long milliseconds = td.total_milliseconds() -
+                              ((hours * 3600 + minutes * 60 + seconds) * 1000);
+    double time = hours * 10000 + minutes * 100 + seconds + ((double)milliseconds)/1000;
+
+    return new Frame(frame, fileName + boost::lexical_cast<string>(time) + ".jpg", reader->get_metadata(time), camera);
+}

--- a/modules/imgimport/src/video_import.cpp
+++ b/modules/imgimport/src/video_import.cpp
@@ -18,11 +18,24 @@
 #include <boost/date_time/posix_time/posix_time.hpp>
 #include <boost/filesystem.hpp>
 #include <ctime>
+#include <cstdlib>
+#include <boost/date_time.hpp>
 
 using namespace cv;
 using namespace std;
 using namespace boost;
 using namespace boost::filesystem;
+namespace bt = boost::posix_time;
+
+static const int HAS_FFPROBE = std::system("which ffprobe > /dev/null") == 0;
+
+static const std::locale dateFormat = std::locale(std::locale::classic(),new bt::time_input_facet("%Y-%m-%dT%H:%M:%sZ"));
+
+std::time_t pt_to_time_t(const bt::ptime& pt) {
+    bt::ptime timet_start(boost::gregorian::date(1970,1,1));
+    bt::time_duration diff = pt - timet_start;
+    return diff.ticks()/bt::time_duration::rep_type::ticks_per_second;
+}
 
 VideoImport::VideoImport(string videoFile, MetadataInput * reader, Camera &camera) : ImageImport(reader, camera) {
     capture.open(videoFile);
@@ -32,8 +45,34 @@ VideoImport::VideoImport(string videoFile, MetadataInput * reader, Camera &camer
     }
     capture.set(CAP_PROP_CONVERT_RGB, true);
     totalFrames = capture.get(CAP_PROP_FRAME_COUNT);
-    fileName = videoFile.find_last_of('/') == string::npos ? videoFile : videoFile.substr(videoFile.find_last_of('/'));
-    videoStartTime = last_write_time(fileName);
+    if (HAS_FFPROBE) {
+        string cmd = "ffprobe -v error -show_entries stream_tags=creation_time:format_tags=creation_time -of default=noprint_wrappers=1:nokey=1 -i " + videoFile + "| head -n 1";
+
+        FILE*           fp;
+        const int       SIZEBUF = 1234;
+        char            buf [SIZEBUF];
+        if ((fp = popen(cmd.c_str (), "r")) != NULL) {
+            std::string  cur_string = "";
+            while (fgets(buf, sizeof (buf), fp)) {
+                cur_string += buf;
+            }
+            string result = cur_string.substr (0, cur_string.size () - 1);
+            BOOST_LOG_TRIVIAL(trace) << "Video start date: " << result;
+            pclose(fp);
+
+            bt::ptime pt;
+            std::istringstream is(result);
+            is.imbue(dateFormat);
+            is >> pt;
+            videoStartTime = pt_to_time_t(pt);
+            BOOST_LOG_TRIVIAL(trace) << "Video start MS from ffprobe creation date: " << videoStartTime;
+        }
+    } else {
+        BOOST_LOG_TRIVIAL(warning) << "Reading video but ffprobe is not available\nvideo frame times will be based on the last write time of the file and may be inaccurate";
+        // Last write time should roughly equal the end of the video, so work backwards using video length to get the start time
+        videoStartTime = last_write_time(videoFile) - totalFrames/capture.get(CAP_PROP_FPS);
+        BOOST_LOG_TRIVIAL(trace) << "Video start MS from last_write_time: " << videoStartTime;
+    }
 }
 
 Frame * VideoImport::next_frame() {

--- a/modules/imgimport/test/test.cpp
+++ b/modules/imgimport/test/test.cpp
@@ -1,9 +1,9 @@
-/* 
+/*
     This file is part of WARG's computer-vision
 
     Copyright (c) 2015, Waterloo Aerial Robotics Group (WARG)
     All rights reserved.
- 
+
     Redistribution and use in source and binary forms, with or without
     modification, are permitted provided that the following conditions are met:
     1. Redistributions of source code must retain the above copyright
@@ -54,5 +54,5 @@ BOOST_AUTO_TEST_CASE(DecklinkVideoSource){
 
     BOOST_CHECK(img.rows > 0);
     delete v;
-   
+
 }


### PR DESCRIPTION
Cleaned up and updated to use new interfaces
Also added a CLI command to show current frame sources

Video start time is retrieved by calling ffprobe if it is available and parsing the output. If ffprobe is not available it prints a warning and instead uses file modification date. This also means that this adds a soft dependency on ffprobe.