### PR TITLE
Made camera have a paramater that doesn't apply undistortion

### DIFF
--- a/modules/core/include/camera.h
+++ b/modules/core/include/camera.h
@@ -34,8 +34,9 @@ public:
      * @param fov The field of view of the camera
      * @param cameraMatrix OpenCV camera calibration matrix giving focal length and principal point
      * @param distortionCoeffs OpenCV distortion coefficients used for undistorting images
+     * #param undistort Whether or not to apply undistortion to images. If false the camera acts as a placeholder that can be used for testing
      */
-    Camera(cv::Size imageSize, cv::Size2d fov, cv::Mat cameraMatrix, cv::Mat distortionCoeffs, cv::Mat newCameraMatrix);
+    Camera(cv::Size imageSize, cv::Size2d fov, cv::Mat cameraMatrix, cv::Mat distortionCoeffs, cv::Mat newCameraMatrix, bool applyUndistort = true);
 
     /**
      * @brief Returns the field of view of the camera in degrees for both horizontal and vertical dimensions
@@ -55,6 +56,7 @@ public:
     static Camera TestCamera();
 
 private:
+    bool applyUndistort;
     cv::Size2d fov;
     cv::Mat cameraMatrix;
     cv::Mat distortionCoeffs;

--- a/modules/core/src/camera.cpp
+++ b/modules/core/src/camera.cpp
@@ -20,14 +20,18 @@
 
 using namespace cv;
 
-Camera::Camera(Size imageSize, Size2d fov, Mat cameraMatrix, Mat distortionCoeffs, Mat newCameraMatrix = Mat())
-        : cameraMatrix(cameraMatrix), distortionCoeffs(distortionCoeffs), newCameraMatrix(newCameraMatrix), fov(fov) {
+Camera::Camera(Size imageSize, Size2d fov, Mat cameraMatrix, Mat distortionCoeffs, Mat newCameraMatrix = Mat(), bool applyUndistort)
+        : cameraMatrix(cameraMatrix), distortionCoeffs(distortionCoeffs), newCameraMatrix(newCameraMatrix), fov(fov), applyUndistort(applyUndistort) {
 }
 
 Mat * Camera::undistort(Mat & img) {
-    Mat *tmp = new Mat();
-    cv::undistort(img, *tmp, cameraMatrix, distortionCoeffs, newCameraMatrix);
-    return tmp;
+    if (applyUndistort) {
+        Mat *tmp = new Mat();
+        cv::undistort(img, *tmp, cameraMatrix, distortionCoeffs, newCameraMatrix);
+        return tmp;
+    } else {
+        return new Mat(img.clone());
+    }
 }
 
 Camera Camera::TestCamera() {
@@ -54,7 +58,7 @@ Camera Camera::TestCamera() {
             Size(5, 1),
             CV_8UC1,
             distMatrix
-        )
+        ), Mat(), false
     );
 }
 

--- a/modules/imgimport/src/decklink_import.cpp
+++ b/modules/imgimport/src/decklink_import.cpp
@@ -151,7 +151,7 @@ Frame* DeckLinkImport::next_frame(){
     } catch (std::exception & e) {
         BOOST_LOG_TRIVIAL(error) << "Error reading metadata: " << e.what();
     }
-    Frame* img = new Frame(&oFrame, boost::lexical_cast<string>(time) + ".jpg", m);
+    Frame* img = new Frame(&oFrame, boost::lexical_cast<string>(time) + ".jpg", m, camera);
     return img;
 }
 #endif

--- a/modules/imgimport/test/test.cpp
+++ b/modules/imgimport/test/test.cpp
@@ -37,6 +37,7 @@
 #include <boost/log/trivial.hpp>
 #include <boost/log/expressions.hpp>
 #include "decklink_import.h"
+#include "camera.h"
 
 using namespace std;
 using namespace boost;
@@ -47,8 +48,8 @@ BOOST_AUTO_TEST_CASE(DecklinkVideoSource){
     if(boost::unit_test::framework::master_test_suite().argc <= 1) {
         BOOST_ERROR("Invalid number of arguments");
     }
-
-    DeckLinkImport * v = new DeckLinkImport(NULL);
+    Camera camera = Camera::TestCamera();
+    DeckLinkImport * v = new DeckLinkImport(NULL, camera);
     cv::Mat img;
     v->grabFrame(&img);
 


### PR DESCRIPTION
Camera::TestCamera now doesn't do undistortion. Should be used in tests if you want to avoid errors caused by images changing due to distortion correction.