### PR TITLE
Guard against invalid clusterIdx (bug in kmeans)

### DIFF
--- a/modules/targetid/src/k_means_filter.cpp
+++ b/modules/targetid/src/k_means_filter.cpp
@@ -77,9 +77,11 @@ cv::Mat * KMeansFilter::filter(const Mat & src) {
 	    int index = x/reductionFactor + (y/reductionFactor) * tmp.cols;
 	    int clusterIdx = labels.at<int>(index, 0);
 
-	    new_image->at<Vec3b>(y, x)[0] = abs(src.at<Vec3b>(y, x)[0] - centers.at<float>(clusterIdx, 0));
-	    new_image->at<Vec3b>(y, x)[1] = abs(src.at<Vec3b>(y, x)[1] - centers.at<float>(clusterIdx, 1));
-	    new_image->at<Vec3b>(y, x)[2] = abs(src.at<Vec3b>(y, x)[2] - centers.at<float>(clusterIdx, 2));
+	    if (clusterIdx >= 0 && clusterIdx < centers.rows) {
+		new_image->at<Vec3b>(y, x)[0] = abs(src.at<Vec3b>(y, x)[0] - centers.at<float>(clusterIdx, 0));
+		new_image->at<Vec3b>(y, x)[1] = abs(src.at<Vec3b>(y, x)[1] - centers.at<float>(clusterIdx, 1));
+		new_image->at<Vec3b>(y, x)[2] = abs(src.at<Vec3b>(y, x)[2] - centers.at<float>(clusterIdx, 2));
+	    }
 	}
     }
     BOOST_LOG_TRIVIAL(trace) << "Reducing Noise...";


### PR DESCRIPTION
The labels matrix seems to sometimes contain values that don't correspond to a centre.
We should perhaps double check that this absolutely is not an issue with our implementation and if it's an issue with the kmeans function report the issue upstream.